### PR TITLE
add ffv01 gretap peer

### DIFF
--- a/conf/general.conf
+++ b/conf/general.conf
@@ -15,6 +15,6 @@ USE_RADVD="0"
 USE_VPN03="0"
 USE_MESHVIEWER="0"
 
-GRE_PEERS=("einstein:81.7.17.20" "fermi:5.199.142.119" "euler:5.199.142.235" "pascal:62.210.243.67" "brewster:89.163.225.33" "newton:78.46.48.196")
+GRE_PEERS=("einstein:81.7.17.20" "fermi:5.199.142.119" "euler:5.199.142.235" "pascal:62.210.243.67" "brewster:89.163.225.33" "newton:78.46.48.196" "ffv01:194.25.105.16")
 
 LOG_DEBUG="0"


### PR DESCRIPTION
vpn01.freifunk-vogtland.net is the new server provided by Freifunk Vogtland. It currently only provides fastd and gretap to other peers. Additional services can be enabled when the service addresses were assigned.

ambassador86  and deusama already have access to the server.
