### PR TITLE
Automatically create conf/bird-routes.country.conf on first startup

### DIFF
--- a/conf/bird-routes.country.conf
+++ b/conf/bird-routes.country.conf
@@ -1,1 +1,0 @@
-# initially this file contains no routes

--- a/lib/bird.sh
+++ b/lib/bird.sh
@@ -27,7 +27,9 @@ bird_init() {
 			bird_add_route "$s"
 		fi
 	done
-	
+
+	touch conf/bird-routes.country.conf
+
 	ip rule add from 10.149.0.0/16 lookup 100
 	ip rule add to 10.149.0.0/16 lookup 100
 	ip route add default via 127.0.0.1 table 100 metric 1024


### PR DESCRIPTION
Having a file tracked by git which gets automatically overwritten by the server-scripts makes it harder to do normal git operations on the repository. Better make sure that the file is create during the initialization of the bird daemon.
